### PR TITLE
Remove dependancy

### DIFF
--- a/game.libretro.yabause/addon.xml.in
+++ b/game.libretro.yabause/addon.xml.in
@@ -6,7 +6,6 @@
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
 		<import addon="game.controller.saturn" version="1.0.0"/>
-		<import addon="game.controller.saturn.3d" version="1.0.0"/>
 		<import addon="game.controller.saturn.multitap" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"


### PR DESCRIPTION
Remove no longer existing dependancy.
game.controller.saturn.3d is also now broken into game.controller.saturn.3d.japan and game.controller.saturn.3d.western, bot I don't believe would be dependancies